### PR TITLE
Downgrade libnvinfer to 7.2.2 for compat with tensorflow 2.11.0

### DIFF
--- a/tensorflow-gpu-base/Dockerfile
+++ b/tensorflow-gpu-base/Dockerfile
@@ -74,7 +74,7 @@ RUN [[ "${ARCH}" = "ppc64le" ]] || { apt-get update && \
         && rm -rf /var/lib/apt/lists/*; }
 
 # For CUDA profiling, TensorFlow requires CUPTI.
-ENV LD_LIBRARY_PATH /usr/local/cuda-11.8/targets/x86_64-linux/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH /usr/local/cuda-11.8/targets/x86_64-linux/lib:/usr/local/cuda-11.1/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 
 # Link the libcuda stub to the location where tensorflow is searching for it and reconfigure
 # dynamic linker run-time bindings

--- a/tensorflow-gpu-base/Dockerfile
+++ b/tensorflow-gpu-base/Dockerfile
@@ -31,8 +31,9 @@ ARG CUDA
 ARG CUDNN=8.6.0.163-1
 ARG CUDNN_MAJOR_VERSION=8
 ARG LIB_DIR_PREFIX=x86_64
-ARG LIBNVINFER=8.4.3-1
-ARG LIBNVINFER_MAJOR_VERSION=8
+# Note: Keeping LIBNVINFER 7.x for compat with tensorflow==2.11.0 -abarrett 2/22/23
+ARG LIBNVINFER=7.2.2-1
+ARG LIBNVINFER_MAJOR_VERSION=7
 
 # Let us install tzdata painlessly
 ENV DEBIAN_FRONTEND=noninteractive
@@ -62,13 +63,13 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         unzip
 
 # Install TensorRT if not building for PowerPC
-# NOTE: libnvinfer uses cuda11.6 versions
+# NOTE: libnvinfer uses cuda11.1 versions
 RUN [[ "${ARCH}" = "ppc64le" ]] || { apt-get update && \
-        apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub && \
-        echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /"  > /etc/apt/sources.list.d/tensorRT.list && \
+        apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub && \
+        echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /"  > /etc/apt/sources.list.d/tensorRT.list && \
         apt-get update && \
-        apt-get install -y --no-install-recommends libnvinfer${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.6 \
-        libnvinfer-plugin${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.6 \
+        apt-get install -y --no-install-recommends libnvinfer${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.1 \
+        libnvinfer-plugin${LIBNVINFER_MAJOR_VERSION}=${LIBNVINFER}+cuda11.1 \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/*; }
 


### PR DESCRIPTION
This PR downgrades `libnvinfer` from 8.x to 7.x so that tensorRT libraries can be used with tensorflow v2.11.0. 

## Issue Description

Given that `tensorflow==2.11.0` is installed from [pypi](https://pypi.org/project/tensorflow/), when we try to list GPU devices, we get the following warning message:

```python
import tensorflow as tf
tf.config.list_physical_devices('GPU')
``` 

> 2023-02-22 17:43:27.237736: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-11.8/targets/x86_64-linux/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

> 2023-02-22 17:43:27.237841: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda-11.8/targets/x86_64-linux/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

> 2023-02-22 17:43:27.237851: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.

After doing a little digging with some help from [SO](https://stackoverflow.com/questions/68450867/how-to-find-the-right-libnvinfer-version-for-cuda/71600882#71600882), it appears that `tensorflow==2.11.0` is linked against [tensorRT 7.2.2](https://docs.nvidia.com/deeplearning/tensorrt/release-notes/index.html#rel_7-2-2), which in turn means it will try to dynamically load `libnvinfer.so.7` and `libnvinfer_plugin.so.7` at runtime, so we need to be sure we have that version installed on the system and that it can be found in the `$LD_LIBRARY_PATH`.

```python
import tensorflow as tf
print(tf.__version__) # output: 2.11.0

from tensorflow.python.compiler.tensorrt import trt_convert as
trt.trt_utils._pywrap_py_utils.get_linked_tensorrt_version() # output: (7, 2, 2)
trt.trt_utils._pywrap_py_utils.get_loaded_tensorrt_version() # errors out
```

## References

- https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html
- https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/
- https://docs.nvidia.com/deploy/cuda-compatibility/index.html
