### PR TITLE
Replace old org name reference

### DIFF
--- a/.github/workflows/docker-tensorflow-gpu-base.yml
+++ b/.github/workflows/docker-tensorflow-gpu-base.yml
@@ -36,8 +36,8 @@ jobs:
           file: ./tensorflow-gpu-base/Dockerfile
           push: true
           tags: |
-            harvardat/tensorflow-gpu-base:${{ env.SHORT_SHA }}
-            harvardat/tensorflow-gpu-base:latest
+            huitacademictechnology/tensorflow-gpu-base:${{ env.SHORT_SHA }}
+            huitacademictechnology/tensorflow-gpu-base:latest
       -
         name: Image digest                  
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Dockerfiles for Jupyterhub.
 **To use this image:**
 
 ```
-$ docker pull harvardat/tensorflow-gpu-base:latest
+$ docker pull huitacademictechnology/tensorflow-gpu-base:latest
 ```
 
 **Description:**
@@ -20,4 +20,4 @@ See the official [gpu.Dockerfile](https://raw.githubusercontent.com/tensorflow/t
 
 ## Automated Builds
 
-Github Actions are setup to automatically build and push images to https://hub.docker.com/u/harvardat. The asusmption is that there is no sensitive information being added to these images.
+Github Actions are setup to automatically build and push images to https://hub.docker.com/u/huitacademictechnology. The asusmption is that there is no sensitive information being added to these images.


### PR DESCRIPTION
I moved the existing images from the free tier org `harvardat` to the paid org `huitacademictechnology`. I did this following [suggestions from the Docker forums](https://forums.docker.com/t/how-to-move-existing-repository-to-an-organisation/123682), which I'll copy for  posterity:

> If you have existing organization, you can download your images from your user, add a new tag to each image to match the name of your organization and push those images to the organization. I don’t know any easier way to move all of your images for example by clicking on a “move” or “migrate” button.
>
> If you are looking for a way to download all of your images from a repository, I think the following command would do the trick:
> 
> ```bash
> export OLD_REPOSITORY=yourusername/imagename
> docker pull $OLD_REPOSITORY --all-tags
> ```
>
>If you don’t have at least PRO subscription, you could probably reach the download rate limit
> 
> Then you can “rename”, in fact, add a new tag to the images:
>
> ```bash
> export OLD_REPOSITORY=yourusername/imagename
> export NEW_REPOSITORY=yourorganizationname/imagename
> docker image ls $OLD_REPOSITORY --format '{{ .Repository }}:{{ .Tag }} {{ .Repository }}:{{ .Tag }}' | sed "s# .*:# $NEW_REPOSITORY:#" | xargs -L 1 -- docker tag
> ```
> 
> Then push them all
> 
> ```bash
> docker push $NEW_REPOSITORY --all-tags
> ```